### PR TITLE
Added 'jira_verify' option to bypass https certificate check.

### DIFF
--- a/issue.py
+++ b/issue.py
@@ -38,7 +38,8 @@ class Issue(object):
     return (
       settings().get('jira_login'),
       settings().get('jira_password'),
-      {'server': settings().get('jira_server')}
+      {'server': settings().get('jira_server'),
+       'verify': settings().get('jira_verify') != 'False' }
     )
 
   def get_issue(self, key):


### PR DESCRIPTION
This new setting enables me to bypass ssl certificate checks. I needed it to bypass certificate issues with my jira server.